### PR TITLE
Added Scope Provider

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<BuildVersion>1.3.1</BuildVersion>
+		<BuildVersion>1.3.2</BuildVersion>
 		<Version>$(BuildVersion)</Version>
 		<AssemblyVersion>$(BuildVersion)</AssemblyVersion>
 		<FileVersion>$(BuildVersion)</FileVersion>

--- a/src/SDI.Abstraction/IScopeProvider.cs
+++ b/src/SDI.Abstraction/IScopeProvider.cs
@@ -1,0 +1,16 @@
+﻿namespace SDI.Abstraction;
+
+/// <summary>
+/// Represents the base interface for a scope provider.
+/// </summary>
+public interface IScopeProvider
+{
+    /// <summary>
+    /// Creates a new service provider scope with the specified identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier for the new scope.</param>
+    /// <returns>
+    /// A new <see cref="IServiceProvider"/> instance representing the created scope.
+    /// </returns>
+    IServiceProvider CreateScope(ScopeId id);
+}

--- a/src/SDI.Abstraction/IServiceController.cs
+++ b/src/SDI.Abstraction/IServiceController.cs
@@ -27,13 +27,4 @@ public interface IServiceController : IServiceProvider
     /// </summary>
     /// <param name="id">The service identifier to unregister.</param>
     void UnregisterService(ServiceId id);
-
-    /// <summary>
-    /// Creates a new service provider scope with the specified identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier for the new scope.</param>
-    /// <returns>
-    /// A new <see cref="IServiceProvider"/> instance representing the created scope.
-    /// </returns>
-    IServiceProvider CreateScope(ScopeId id);
 }

--- a/src/SDI.Abstraction/IServiceProvider.cs
+++ b/src/SDI.Abstraction/IServiceProvider.cs
@@ -7,7 +7,7 @@ namespace SDI.Abstraction;
 /// Represents the base interface for a service provider within a specific dependency injection scope.
 /// Extends the standard <see cref="System.IServiceProvider"/> with scope-aware capabilities.
 /// </summary>
-public interface IServiceProvider : System.IServiceProvider, IDisposable
+public interface IServiceProvider : System.IServiceProvider, IScopeProvider, IDisposable
 {
     /// <summary>
     /// Gets the scope identifier that this service provider is associated with.

--- a/src/SDI/ServiceController.cs
+++ b/src/SDI/ServiceController.cs
@@ -170,6 +170,8 @@ public class ServiceController : IServiceController
 
         public IEnumerable GetServices(ServiceId id) => InternalGetController().GetServices(id, this);
 
+        public IServiceProvider CreateScope(ScopeId id) => InternalGetController().CreateScope(id);
+
         public void Dispose()
         {
             InternalDeinitialize();


### PR DESCRIPTION
A new interface 'IScopeProvider' has been added indicating that the specified object can create a Scope.

IServiceProvider can implement 'IScopeProvider'.